### PR TITLE
Add JSON functionality

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,8 +41,9 @@ func (c *client) Get(k string) (string, error) {
 	return string(reader), nil
 }
 
-// GetJSON creates or updates the provided key with the JSON serialization of
-// the provided value.
+// GetJSON retrieves the JSON string data for the provided key, deserializes it
+// and saves it to the value pointed to by `value`.
+// It returns ErrNotFound if the key does not exist.
 func (c *client) GetJSON(k string, v interface{}) error {
 	body, err := c.GetReader(k)
 	if err != nil {

--- a/database.go
+++ b/database.go
@@ -36,6 +36,18 @@ func Get(key string) (string, error) {
 	return c.Get(key)
 }
 
+// GetJSON retrieves the JSON string data for the provided key, deserializes it
+// and saves it to value pointed to by `value`.
+// It returns ErrNotFound if the key does not exist.
+func GetJSON(key string, value interface{}) error {
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	return c.GetJSON(key, value)
+}
+
 // Set creates or updates the provided key with the provided value.
 func Set(key, value string) error {
 	c, err := getClient()
@@ -44,6 +56,17 @@ func Set(key, value string) error {
 	}
 
 	return c.Set(key, value)
+}
+
+// SetJSON creates or updates the provided key with the JSON serialization of
+// the provided value.
+func SetJSON(key string, value interface{}) error {
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	return c.SetJSON(key, value)
 }
 
 // Delete removes the provided key.

--- a/database_test.go
+++ b/database_test.go
@@ -54,6 +54,31 @@ func TestSingleton(t *testing.T) {
 	_, err = Get(prefix + "test")
 	assert.Equal(t, ErrNotFound, err)
 
+	// testing JSON
+	mapValue := map[string]int{
+		"one": 1,
+		"two": 2,
+	}
+
+	err = SetJSON(prefix+"test", mapValue)
+	assert.NoError(t, err)
+
+	val, err = Get(prefix + "test")
+	assert.NoError(t, err)
+	assert.Equal(t, `{"one":1,"two":2}`, val)
+
+	decoded := make(map[string]int)
+
+	err = GetJSON(prefix+"test", &decoded)
+	assert.NoError(t, err)
+	assert.Equal(t, mapValue, decoded)
+
+	err = Delete(prefix + "test")
+	assert.NoError(t, err)
+
+	err = GetJSON(prefix+"test", decoded)
+	assert.Equal(t, ErrNotFound, err)
+
 	// listing keys
 	for i := 0; i < 50; i++ {
 		err = Set(fmt.Sprintf("%stest-%02d", prefix, i), "value")


### PR DESCRIPTION
Exposes the `GetJSON` and `SetJSON` methods from `client.go` so users can get and set non-string types.

All the tests in `database_test.go` were lumped into one, so I added unit tests into that, but I'd be happy to separate them out if that would be better.