### PR TITLE
Optionally read the Replit DB URL from a file

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,7 +8,7 @@ blocks:
   - name: Test
     task:
       jobs:
-        - name: make test
+        - name: Test (JWT)
           commands:
             - sem-version go 1.14
             - export GO111MODULE=on
@@ -16,5 +16,13 @@ blocks:
             - 'export PATH=/home/semaphore/go/bin:$PATH'
             - checkout
             - make test
+        - name: Test (RIDT)
+          commands:
+            - sem-version go 1.14
+            - export GO111MODULE=on
+            - export GOPATH=~/go
+            - 'export PATH=/home/semaphore/go/bin:$PATH'
+            - checkout
+            - RIDT_DB=1 make test
       secrets:
         - name: replit-database

--- a/database_test.go
+++ b/database_test.go
@@ -15,6 +15,34 @@ var setup sync.Once
 
 func setDBURL(t *testing.T) {
 	setup.Do(func() {
+		_, ok := os.LookupEnv("USE_FILE")
+		if ok {
+			fmt.Println("using file for db url")
+			req, err := http.NewRequest("GET", "https://database-test-ridt.util.repl.co", nil)
+			assert.NoError(t, err)
+
+			pass, ok := os.LookupEnv("RIDT_PASSWORD")
+			if !ok {
+				panic("please set RIDT_PASSWORD env var")
+			}
+			req.SetBasicAuth("test", pass)
+			resp, err := http.DefaultClient.Do(req)
+			assert.NoError(t, err)
+			assert.Equal(t, 200, resp.StatusCode)
+			defer resp.Body.Close()
+
+			b, err := ioutil.ReadAll(resp.Body)
+			assert.NoError(t, err)
+
+			// write to /tmp/replitdb
+			err = os.MkdirAll("tmp", 0755)
+
+			err = ioutil.WriteFile(replitDBURLFile, b, 0644)
+
+			assert.NoError(t, err)
+			return
+		}
+
 		req, err := http.NewRequest("GET", "https://database-test-jwt.util.repl.co", nil)
 		assert.NoError(t, err)
 

--- a/database_test.go
+++ b/database_test.go
@@ -15,7 +15,7 @@ var setup sync.Once
 
 func setDBURL(t *testing.T) {
 	setup.Do(func() {
-		_, ok := os.LookupEnv("USE_FILE")
+		_, ok := os.LookupEnv("RIDT_DB")
 		if ok {
 			fmt.Println("using file for db url")
 			req, err := http.NewRequest("GET", "https://database-test-ridt.util.repl.co", nil)


### PR DESCRIPTION
# Why

The JWT used for authenticating into the Replit DB is placed on the Repl as an environment variable on boot and lasts for 30h or so. This is fine for shorter lasting Repls, but if we want to have long-running Repls we need a mechanism to refresh the DB token.

# What changed

Let's make it so that we read the DB URL data from a file, which can be refreshed while a program is running. If the file does not exist or we fail to read from it, fall back to the environment variable.

# Testing

We need to set the `RIDT_PASSWORD` to the token used for authing into database-test-ridt.util.repl.co. You can find it in that Repl's secrets. To store the database URL in a file instead of the env var, set the `USE_FILE` environment variable to anything.

```
 make test RIDT_DB=1 RIDT_PASSWORD=<PASSWORD>
```