### PR TITLE
Refresh client periodically

### DIFF
--- a/client.go
+++ b/client.go
@@ -242,7 +242,6 @@ func newClientWithCustomURL(urlStr string) (*client, error) {
 			Timeout: 10 * time.Second,
 		},
 		baseURL: u,
-        creationTime: time.Now(),
 	}
 
 	return c, nil

--- a/client.go
+++ b/client.go
@@ -242,6 +242,7 @@ func newClientWithCustomURL(urlStr string) (*client, error) {
 			Timeout: 10 * time.Second,
 		},
 		baseURL: u,
+        creationTime: time.Now(),
 	}
 
 	return c, nil

--- a/database.go
+++ b/database.go
@@ -4,17 +4,28 @@ package database
 
 import (
 	"sync"
+    "time"
 )
 
 var defaultClient = struct {
 	sync.Mutex
 	c *client
 	o sync.Once
+    creationTime time.Time
 }{}
+
+const (
+    refreshInteval = 1 * time.Hour
+)
 
 func getClient() (*client, error) {
 	defaultClient.Lock()
 	defer defaultClient.Unlock()
+    // if the client hasn't been updated in 1h, refresh it
+    if time.Since(defaultClient.creationTime) >= refreshInterval {
+        defaultClient.c = nil
+    }
+        
 	if defaultClient.c == nil {
 		c, err := newClient()
 		if err != nil {

--- a/database.go
+++ b/database.go
@@ -4,34 +4,35 @@ package database
 
 import (
 	"sync"
-    "time"
+	"time"
 )
 
 var defaultClient = struct {
 	sync.Mutex
-	c *client
-	o sync.Once
-    creationTime time.Time
+	c            *client
+	o            sync.Once
+	creationTime time.Time
 }{}
 
 const (
-    refreshInteval = 1 * time.Hour
+	refreshInterval = 1 * time.Hour
 )
 
 func getClient() (*client, error) {
 	defaultClient.Lock()
 	defer defaultClient.Unlock()
-    // if the client hasn't been updated in 1h, refresh it
-    if time.Since(defaultClient.creationTime) >= refreshInterval {
-        defaultClient.c = nil
-    }
-        
+	// if the client hasn't been updated in 1h, refresh it
+	if time.Since(defaultClient.creationTime) >= refreshInterval {
+		defaultClient.c = nil
+	}
+
 	if defaultClient.c == nil {
 		c, err := newClient()
 		if err != nil {
 			return nil, err
 		}
 		defaultClient.c = c
+		defaultClient.creationTime = time.Now()
 	}
 	return defaultClient.c, nil
 }


### PR DESCRIPTION
The token we use to authenticate with the DB has an expiration. In some occasions, then, a client may try to authenticate with an expired token. 

This PR refreshes the authentication token hourly to make sure we're always up-to-date.